### PR TITLE
Implementation of `BiWFλ` (BiWFlambda)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ ifndef BUILD_TOOLS
 BUILD_TOOLS=1
 endif
 ifndef BUILD_WFA_PARALLEL
-BUILD_WFA_PARALLEL=1
+BUILD_WFA_PARALLEL=0
 endif
 
 ###############################################################################

--- a/bindings/cpp/WFAligner.cpp
+++ b/bindings/cpp/WFAligner.cpp
@@ -70,7 +70,14 @@ WFAligner::AlignmentStatus WFAligner::alignEnd2EndLambda(
   // Configure
   wavefront_aligner_set_alignment_end_to_end(wfAligner);
   // Align (using custom matching function)
-  return (WFAligner::AlignmentStatus) wavefront_align(wfAligner,NULL,patternLength,NULL,textLength);
+  int* pattern_lambda = (int*)mm_allocator_malloc(wfAligner->mm_allocator,patternLength*sizeof(int));
+  for (int i=0;i<patternLength;i++) { pattern_lambda[i] = i; }
+  int* text_lambda = (int*)mm_allocator_malloc(wfAligner->mm_allocator,textLength*sizeof(int));
+  for (int i=0;i<textLength;i++) { text_lambda[i] = i; }
+  int status = wavefront_align(wfAligner,NULL,pattern_lambda,patternLength,NULL,text_lambda,textLength);
+  mm_allocator_free(wfAligner->mm_allocator,pattern_lambda);
+  mm_allocator_free(wfAligner->mm_allocator,text_lambda);
+  return (WFAligner::AlignmentStatus) status;
 }
 WFAligner::AlignmentStatus WFAligner::alignEnd2End(
     const char* const pattern,
@@ -80,7 +87,7 @@ WFAligner::AlignmentStatus WFAligner::alignEnd2End(
   // Configure
   wavefront_aligner_set_alignment_end_to_end(wfAligner);
   // Align
-  return (WFAligner::AlignmentStatus) wavefront_align(wfAligner,pattern,patternLength,text,textLength);
+  return (WFAligner::AlignmentStatus) wavefront_align(wfAligner,pattern,NULL,patternLength,text,NULL,textLength);
 }
 WFAligner::AlignmentStatus WFAligner::alignEnd2End(
     std::string& pattern,
@@ -103,7 +110,13 @@ WFAligner::AlignmentStatus WFAligner::alignEndsFreeLambda(
       patternBeginFree,patternEndFree,
       textBeginFree,textEndFree);
   // Align (using custom matching function)
-  return (WFAligner::AlignmentStatus) wavefront_align(wfAligner,NULL,patternLength,NULL,textLength);
+  int* pattern_lambda = (int*)mm_allocator_malloc(wfAligner->mm_allocator,patternLength*sizeof(int));
+  for (int i=0;i<patternLength;i++) { pattern_lambda[i] = i; }
+  int* text_lambda = (int*)mm_allocator_malloc(wfAligner->mm_allocator,textLength*sizeof(int));
+  for (int i=0;i<textLength;i++) { text_lambda[i] = i; }
+  int status = wavefront_align(wfAligner,NULL,pattern_lambda,patternLength,NULL,text_lambda,textLength);
+  mm_allocator_free(wfAligner->mm_allocator,pattern_lambda);
+  return (WFAligner::AlignmentStatus) status;
 }
 WFAligner::AlignmentStatus WFAligner::alignEndsFree(
     const char* const pattern,
@@ -119,7 +132,7 @@ WFAligner::AlignmentStatus WFAligner::alignEndsFree(
       patternBeginFree,patternEndFree,
       textBeginFree,textEndFree);
   // Align
-  return (WFAligner::AlignmentStatus) wavefront_align(wfAligner,pattern,patternLength,text,textLength);
+  return (WFAligner::AlignmentStatus) wavefront_align(wfAligner,pattern,NULL,patternLength,text,NULL,textLength);
 }
 WFAligner::AlignmentStatus WFAligner::alignEndsFree(
     std::string& pattern,

--- a/examples/wfa_adapt.c
+++ b/examples/wfa_adapt.c
@@ -50,7 +50,7 @@ int main(int argc,char* argv[]) {
   // Initialize Wavefront Aligner
   wavefront_aligner_t* const wf_aligner = wavefront_aligner_new(&attributes);
   // Align
-  wavefront_align(wf_aligner,pattern,strlen(pattern),text,strlen(text));
+  wavefront_align(wf_aligner,pattern,NULL,strlen(pattern),text,NULL,strlen(text));
   fprintf(stderr,"WFA-Alignment returns score %d\n",wf_aligner->cigar->score);
   // Count mismatches, deletions, and insertions
   int i, misms=0, ins=0, del=0;

--- a/examples/wfa_basic.c
+++ b/examples/wfa_basic.c
@@ -45,7 +45,7 @@ int main(int argc,char* argv[]) {
   // Initialize Wavefront Aligner
   wavefront_aligner_t* const wf_aligner = wavefront_aligner_new(&attributes);
   // Align
-  wavefront_align(wf_aligner,pattern,strlen(pattern),text,strlen(text));
+  wavefront_align(wf_aligner,pattern,NULL,strlen(pattern),text,NULL,strlen(text));
   fprintf(stderr,"WFA-Alignment returns score %d\n",wf_aligner->cigar->score);
   // Display alignment
   fprintf(stderr,"  PATTERN  %s\n",pattern);

--- a/examples/wfa_repeated.c
+++ b/examples/wfa_repeated.c
@@ -48,7 +48,7 @@ int main(int argc,char* argv[]) {
   int i;
   for (i=0;i<100000;++i) {
     // Align
-    wavefront_align(wf_aligner,pattern,strlen(pattern),text,strlen(text));
+    wavefront_align(wf_aligner,pattern,NULL,strlen(pattern),text,NULL,strlen(text));
     // Report
     if ((i%1000) == 0) {
       fprintf(stderr,"... done %d alignments\n",i);

--- a/tools/align_benchmark/align_benchmark.c
+++ b/tools/align_benchmark/align_benchmark.c
@@ -113,7 +113,7 @@ void align_pairwise_test() {
   wavefront_aligner_t* const wf_aligner = wavefront_aligner_new(&attributes);
   // Align
   wavefront_align(wf_aligner,
-      pattern,strlen(pattern),text,strlen(text));
+      pattern,NULL,strlen(pattern),text,NULL,strlen(text));
   // CIGAR
   fprintf(stderr,">> WFA2");
   cigar_print_pretty(stderr,

--- a/tools/align_benchmark/benchmark/benchmark_edit.c
+++ b/tools/align_benchmark/benchmark/benchmark_edit.c
@@ -138,8 +138,8 @@ void benchmark_edit_wavefront(
   // Align
   timer_start(&align_input->timer);
   wavefront_align(wf_aligner,
-      align_input->pattern,align_input->pattern_length,
-      align_input->text,align_input->text_length);
+      align_input->pattern,NULL,align_input->pattern_length,
+      align_input->text,NULL,align_input->text_length);
   timer_stop(&align_input->timer);
   // DEBUG
   if (align_input->debug_flags) {

--- a/tools/align_benchmark/benchmark/benchmark_gap_affine.c
+++ b/tools/align_benchmark/benchmark/benchmark_gap_affine.c
@@ -136,8 +136,8 @@ void benchmark_gap_affine_wavefront(
   // Align
   timer_start(&align_input->timer);
   wavefront_align(wf_aligner,
-      align_input->pattern,align_input->pattern_length,
-      align_input->text,align_input->text_length);
+      align_input->pattern,NULL,align_input->pattern_length,
+      align_input->text,NULL,align_input->text_length);
   timer_stop(&align_input->timer);
   // DEBUG
   if (align_input->debug_flags) {

--- a/tools/align_benchmark/benchmark/benchmark_gap_affine2p.c
+++ b/tools/align_benchmark/benchmark/benchmark_gap_affine2p.c
@@ -75,8 +75,8 @@ void benchmark_gap_affine2p_wavefront(
   // Align
   timer_start(&align_input->timer);
   wavefront_align(wf_aligner,
-      align_input->pattern,align_input->pattern_length,
-      align_input->text,align_input->text_length);
+      align_input->pattern,NULL,align_input->pattern_length,
+      align_input->text,NULL,align_input->text_length);
   timer_stop(&align_input->timer);
   // DEBUG
   if (align_input->debug_flags) {

--- a/tools/align_benchmark/benchmark/benchmark_gap_linear.c
+++ b/tools/align_benchmark/benchmark/benchmark_gap_linear.c
@@ -74,8 +74,8 @@ void benchmark_gap_linear_wavefront(
   // Align
   timer_start(&align_input->timer);
   wavefront_align(wf_aligner,
-      align_input->pattern,align_input->pattern_length,
-      align_input->text,align_input->text_length);
+      align_input->pattern,NULL,align_input->pattern_length,
+      align_input->text,NULL,align_input->text_length);
   timer_stop(&align_input->timer);
   // DEBUG
   if (align_input->debug_flags) {

--- a/tools/align_benchmark/benchmark/benchmark_indel.c
+++ b/tools/align_benchmark/benchmark/benchmark_indel.c
@@ -43,8 +43,8 @@ void benchmark_indel_wavefront(
   // Align
   timer_start(&align_input->timer);
   wavefront_align(wf_aligner,
-      align_input->pattern,align_input->pattern_length,
-      align_input->text,align_input->text_length);
+      align_input->pattern,NULL,align_input->pattern_length,
+      align_input->text,NULL,align_input->text_length);
   timer_stop(&align_input->timer);
   // DEBUG
   if (align_input->debug_flags) {

--- a/utils/string_padded.c
+++ b/utils/string_padded.c
@@ -63,6 +63,37 @@ void strings_padded_add_padding(
   // Add end padding
   memset(*buffer_padded_begin+buffer_length,padding_value,end_padding_length);
 }
+/*
+ * Strings (text/pattern) lambda padded
+ */
+void strings_padded_add_padding_lambda(
+    const int* const buffer,
+    const int buffer_length,
+    const int begin_padding_length,
+    const int end_padding_length,
+    const int padding_value,
+    int** const buffer_padded,
+    int** const buffer_padded_begin,
+    const bool reverse_sequence,
+    mm_allocator_t* const mm_allocator) {
+  // Allocate
+  const int buffer_padded_length = begin_padding_length + buffer_length + end_padding_length;
+  *buffer_padded = mm_allocator_malloc(mm_allocator,buffer_padded_length*sizeof(int));
+  // Add begin padding (memset(*buffer_padded,padding_value,begin_padding_length);)
+  for (int i=0;i<begin_padding_length;i++) {(*buffer_padded)[i] = padding_value; }
+  // Copy buffer
+  *buffer_padded_begin = *buffer_padded + begin_padding_length;
+  if (reverse_sequence) {
+      int i;
+      for (i=0;i<buffer_length;i++) {
+          (*buffer_padded_begin)[i] = buffer[buffer_length-1-i];
+      }
+  } else {
+      memcpy(*buffer_padded_begin,buffer,buffer_length*sizeof(int));
+  }
+  // Add end padding (memset(*buffer_padded_begin+buffer_length,padding_value,end_padding_length);)
+  for (int i=0;i<end_padding_length;i++) {(*buffer_padded_begin+buffer_length)[i] = padding_value; }
+}
 strings_padded_t* strings_padded_new(
     const char* const pattern,
     const int pattern_length,
@@ -98,8 +129,10 @@ strings_padded_t* strings_padded_new(
 }
 strings_padded_t* strings_padded_new_rhomb(
     const char* const pattern,
+    const int* const pattern_lambda,
     const int pattern_length,
     const char* const text,
+    const int* const text_lambda,
     const int text_length,
     const int padding_length,
     const bool reverse_sequences,
@@ -114,18 +147,33 @@ strings_padded_t* strings_padded_new_rhomb(
   const int text_begin_padding_length = padding_length;
   const int text_end_padding_length = text_length + padding_length;
   // Add padding
-  strings_padded_add_padding(
-      pattern,pattern_length,
-      pattern_begin_padding_length,pattern_end_padding_length,'?',
-      &(strings_padded->pattern_padded_buffer),
-      &(strings_padded->pattern_padded),
-      reverse_sequences,mm_allocator);
-  strings_padded_add_padding(
-      text,text_length,
-      text_begin_padding_length,text_end_padding_length,'!',
-      &(strings_padded->text_padded_buffer),
-      &(strings_padded->text_padded),
-      reverse_sequences,mm_allocator);
+  if (pattern != NULL && text != NULL) {
+    strings_padded_add_padding(
+            pattern,pattern_length,
+            pattern_begin_padding_length,pattern_end_padding_length,'?',
+            &(strings_padded->pattern_padded_buffer),
+            &(strings_padded->pattern_padded),
+            reverse_sequences,mm_allocator);
+    strings_padded_add_padding(
+            text,text_length,
+            text_begin_padding_length,text_end_padding_length,'!',
+            &(strings_padded->text_padded_buffer),
+            &(strings_padded->text_padded),
+            reverse_sequences,mm_allocator);
+  } else if (pattern_lambda != NULL && text_lambda != NULL) {
+    strings_padded_add_padding_lambda(
+            pattern_lambda,pattern_length,
+            pattern_begin_padding_length,pattern_end_padding_length,-1,
+            &(strings_padded->pattern_lambda_padded_buffer),
+            &(strings_padded->pattern_lambda_padded),
+            reverse_sequences,mm_allocator);
+    strings_padded_add_padding_lambda(
+            text_lambda,text_length,
+            text_begin_padding_length,text_end_padding_length,-1,
+            &(strings_padded->text_lambda_padded_buffer),
+            &(strings_padded->text_lambda_padded),
+            reverse_sequences,mm_allocator);
+  }
   // Set lengths
   strings_padded->pattern_length = pattern_length;
   strings_padded->text_length = text_length;
@@ -135,5 +183,10 @@ strings_padded_t* strings_padded_new_rhomb(
 void strings_padded_delete(strings_padded_t* const strings_padded) {
   mm_allocator_free(strings_padded->mm_allocator,strings_padded->pattern_padded_buffer);
   mm_allocator_free(strings_padded->mm_allocator,strings_padded->text_padded_buffer);
+  mm_allocator_free(strings_padded->mm_allocator,strings_padded);
+}
+void strings_padded_delete_lambda(strings_padded_t* const strings_padded) {
+  mm_allocator_free(strings_padded->mm_allocator,strings_padded->pattern_lambda_padded_buffer);
+  mm_allocator_free(strings_padded->mm_allocator,strings_padded->text_lambda_padded_buffer);
   mm_allocator_free(strings_padded->mm_allocator,strings_padded);
 }

--- a/utils/string_padded.h
+++ b/utils/string_padded.h
@@ -47,10 +47,14 @@ typedef struct {
   int text_length;
   // Padded strings
   char* pattern_padded;
+  int* pattern_lambda_padded;
   char* text_padded;
+  int* text_lambda_padded;
   // MM
   char* pattern_padded_buffer;
+  int* pattern_lambda_padded_buffer;
   char* text_padded_buffer;
+  int* text_lambda_padded_buffer;
   mm_allocator_t* mm_allocator;
 } strings_padded_t;
 
@@ -67,13 +71,16 @@ strings_padded_t* strings_padded_new(
     mm_allocator_t* const mm_allocator);
 strings_padded_t* strings_padded_new_rhomb(
     const char* const pattern,
+    const int* const pattern_lambda,
     const int pattern_length,
     const char* const text,
+    const int* const text_lambda,
     const int text_length,
     const int padding_length,
     const bool reverse_sequences,
     mm_allocator_t* const mm_allocator);
 void strings_padded_delete(
     strings_padded_t* const strings_padded);
-
+void strings_padded_delete_lambda(
+    strings_padded_t* const strings_padded);
 #endif /* STRING_PADDED_H_ */

--- a/wavefront/wavefront_align.c
+++ b/wavefront/wavefront_align.c
@@ -109,12 +109,14 @@ void wavefront_align_unidirectional_cleanup(
 void wavefront_align_unidirectional(
     wavefront_aligner_t* const wf_aligner,
     const char* const pattern,
+    const int* const pattern_lambda,
     const int pattern_length,
     const char* const text,
+    const int* const text_lambda,
     const int text_length) {
   // Prepare alignment
   wavefront_unialign_init(
-      wf_aligner,pattern,pattern_length,text,text_length,
+      wf_aligner,pattern,pattern_lambda,pattern_length,text,text_lambda,text_length,
       affine2p_matrix_M,affine2p_matrix_M);
   // DEBUG
   wavefront_debug_prologue(wf_aligner,pattern,pattern_length,text,text_length);
@@ -133,13 +135,15 @@ void wavefront_align_unidirectional(
 void wavefront_align_bidirectional(
     wavefront_aligner_t* const wf_aligner,
     const char* const pattern,
+    const int* const pattern_lambda,
     const int pattern_length,
     const char* const text,
+    const int* const text_lambda,
     const int text_length) {
   // DEBUG
   wavefront_debug_prologue(wf_aligner,pattern,pattern_length,text,text_length);
   // Bidirectional alignment
-  wavefront_bialign(wf_aligner,pattern,pattern_length,text,text_length);
+  wavefront_bialign(wf_aligner,pattern,pattern_lambda,pattern_length,text,text_lambda,text_length);
   // Finish
   const uint64_t memory_used = wavefront_aligner_get_size(wf_aligner);
   wf_aligner->align_status.memory_used = memory_used;
@@ -153,8 +157,10 @@ void wavefront_align_bidirectional(
 int wavefront_align(
     wavefront_aligner_t* const wf_aligner,
     const char* const pattern,
+    int* const pattern_lambda,
     const int pattern_length,
     const char* const text,
+    int* const text_lambda,
     const int text_length) {
   // Checks
   wavefront_align_checks(wf_aligner,pattern_length,text_length);
@@ -164,9 +170,9 @@ int wavefront_align(
   }
   // Dispatcher
   if (wf_aligner->bialigner != NULL) {
-    wavefront_align_bidirectional(wf_aligner,pattern,pattern_length,text,text_length);
+    wavefront_align_bidirectional(wf_aligner,pattern,pattern_lambda,pattern_length,text,text_lambda,text_length);
   } else {
-    wavefront_align_unidirectional(wf_aligner,pattern,pattern_length,text,text_length);
+    wavefront_align_unidirectional(wf_aligner,pattern,pattern_lambda,pattern_length,text,text_lambda,text_length);
   }
   // Return
   return wf_aligner->align_status.status;

--- a/wavefront/wavefront_align.h
+++ b/wavefront/wavefront_align.h
@@ -40,8 +40,10 @@
 int wavefront_align(
     wavefront_aligner_t* const wf_aligner,
     const char* const pattern,
+    int* const pattern_lambda,
     const int pattern_length,
     const char* const text,
+    int* const text_lambda,
     const int text_length);
 int wavefront_align_resume(
     wavefront_aligner_t* const wf_aligner);

--- a/wavefront/wavefront_aligner.c
+++ b/wavefront/wavefront_aligner.c
@@ -223,7 +223,11 @@ void wavefront_aligner_reap(
     wavefront_aligner_t* const wf_aligner) {
   // Padded sequences
   if (wf_aligner->sequences != NULL) {
-    strings_padded_delete(wf_aligner->sequences);
+    if (wf_aligner->match_funct == NULL) {
+      strings_padded_delete(wf_aligner->sequences);
+    } else {
+      strings_padded_delete_lambda(wf_aligner->sequences);
+    }
     wf_aligner->sequences = NULL;
   }
   // Select alignment mode
@@ -243,7 +247,11 @@ void wavefront_aligner_delete(
   const bool mm_allocator_own = wf_aligner->mm_allocator_own;
   // Padded sequences
   if (wf_aligner->sequences != NULL) {
-    strings_padded_delete(wf_aligner->sequences);
+    if (wf_aligner->match_funct == NULL) {
+      strings_padded_delete(wf_aligner->sequences);
+    } else {
+      strings_padded_delete_lambda(wf_aligner->sequences);
+    }
   }
   // Select alignment mode
   if (wf_aligner->bialigner != NULL) {

--- a/wavefront/wavefront_aligner.h
+++ b/wavefront/wavefront_aligner.h
@@ -67,13 +67,14 @@ char* wavefront_align_strerror(const int error_code);
 typedef struct _wavefront_aligner_t wavefront_aligner_t;
 typedef struct {
   // Status
-  int status;                                                     // Status code
-  int score;                                                      // Current WF-alignment score
-  int num_null_steps;                                             // Total contiguous null-steps performed
-  uint64_t memory_used;                                           // Total memory used
+  int status;                                                                    // Status code
+  int score;                                                                     // Current WF-alignment score
+  int num_null_steps;                                                            // Total contiguous null-steps performed
+  uint64_t memory_used;                                                          // Total memory used
   // Wavefront alignment functions
-  void (*wf_align_compute)(wavefront_aligner_t* const,const int); // WF Compute function
-  int (*wf_align_extend)(wavefront_aligner_t* const,const int);   // WF Extend function
+  void (*wf_align_compute)(wavefront_aligner_t* const,const int);                // WF Compute function
+  int (*wf_align_extend)(wavefront_aligner_t* const,const int);                  // WF Extend function
+  int (*wf_align_extend_max)(wavefront_aligner_t* const,const int,int* const);   // WF Extend function (for BiWFA)
 } wavefront_align_status_t;
 
 /*
@@ -98,8 +99,10 @@ typedef struct _wavefront_aligner_t {
   // Sequences
   strings_padded_t* sequences;                // Padded sequences
   char* pattern;                              // Pattern sequence (padded)
+  int* pattern_lambda;                        // Pattern sequence (padded)
   int pattern_length;                         // Pattern length
   char* text;                                 // Text sequence (padded)
+  int* text_lambda;                           // Text sequence (padded)
   int text_length;                            // Text length
   // Custom function to compare sequences
   alignment_match_funct_t match_funct;        // Custom matching function (match(v,h,args))

--- a/wavefront/wavefront_bialign.h
+++ b/wavefront/wavefront_bialign.h
@@ -40,8 +40,10 @@
 void wavefront_bialign(
     wavefront_aligner_t* const wf_aligner,
     const char* const pattern,
+    const int* const pattern_lambda,
     const int pattern_length,
     const char* const text,
+    const int* const text_lambda,
     const int text_length);
 
 #endif /* WAVEFRONT_BIALIGN_H_ */

--- a/wavefront/wavefront_extend.c
+++ b/wavefront/wavefront_extend.c
@@ -331,9 +331,7 @@ int wavefront_extend_end2end_max(
       wavefront_compute_thread_limits(
           omp_get_thread_num(),omp_get_num_threads(),lo,hi,&t_lo,&t_hi);
       wf_offset_t t_max_antidiag = wavefront_extend_matches_packed_max(wf_aligner,mwavefront,t_lo,t_hi);
-      #ifdef WFA_PARALLEL
       #pragma omp critical
-      #endif
       {
         if (t_max_antidiag > max_antidiag) max_antidiag = t_max_antidiag;
       }

--- a/wavefront/wavefront_extend.c
+++ b/wavefront/wavefront_extend.c
@@ -276,9 +276,11 @@ bool wavefront_extend_matches_custom(
     wf_offset_t offset = offsets[k];
     if (offset == WAVEFRONT_OFFSET_NULL) continue;
     // Count equal characters
+    int* pattern_lambda = wf_aligner->pattern_lambda;
+    int* text_lambda = wf_aligner->text_lambda;
     int v = WAVEFRONT_V(k,offset);
     int h = WAVEFRONT_H(k,offset);
-    while (match_funct(v,h,func_arguments)) {
+    while (match_funct(pattern_lambda[v],text_lambda[h],func_arguments)) {
       h++; v++; offset++;
     }
     // Update offset
@@ -290,6 +292,38 @@ bool wavefront_extend_matches_custom(
   }
   // Alignment not finished
   return false;
+}
+wf_offset_t wavefront_extend_matches_custom_max(
+        wavefront_aligner_t* const wf_aligner,
+        wavefront_t* const mwavefront,
+        const int lo,
+        const int hi) {
+    // Parameters (custom matching function)
+    alignment_match_funct_t match_funct = wf_aligner->match_funct;
+    void* const func_arguments = wf_aligner->match_funct_arguments;
+    // Extend diagonally each wavefront point
+    wf_offset_t* const offsets = mwavefront->offsets;
+    wf_offset_t max_antidiag = 0;
+    int k;
+    for (k=lo;k<=hi;++k) {
+        // Check offset
+        wf_offset_t offset = offsets[k];
+        if (offset == WAVEFRONT_OFFSET_NULL) continue;
+        // Count equal characters
+        int* pattern_lambda = wf_aligner->pattern_lambda;
+        int* text_lambda = wf_aligner->text_lambda;
+        int v = WAVEFRONT_V(k,offset);
+        int h = WAVEFRONT_H(k,offset);
+        while (match_funct(pattern_lambda[v],text_lambda[h],func_arguments)) {
+            h++; v++; offset++;
+        }
+        // Update offset
+        offsets[k] = offset;
+        // Compute max
+        const wf_offset_t antidiag = WAVEFRONT_ANTIDIAGONAL(k,offsets[k]);
+        if (max_antidiag < antidiag) max_antidiag = antidiag;
+    }
+    return max_antidiag;
 }
 /*
  * Wavefront exact "extension"
@@ -510,5 +544,61 @@ int wavefront_extend_custom(
   }
   return 0; // Not done
 }
-
-
+int wavefront_extend_custom_max(
+        wavefront_aligner_t* const wf_aligner,
+        const int score,
+        int* const max_antidiagonal) {
+    // Compute score
+    const bool memory_modular = wf_aligner->wf_components.memory_modular;
+    const int max_score_scope = wf_aligner->wf_components.max_score_scope;
+    const int score_mod = (memory_modular) ? score % max_score_scope : score;
+    *max_antidiagonal = 0; // Init
+    // Fetch m-wavefront
+    wavefront_t* const mwavefront = wf_aligner->wf_components.mwavefronts[score_mod];
+    if (mwavefront == NULL) {
+        // Check alignment feasibility (for heuristic variants that can lead to no solution)
+        if (wf_aligner->align_status.num_null_steps > wf_aligner->wf_components.max_score_scope) {
+            wf_aligner->align_status.status = WF_STATUS_UNFEASIBLE;
+            wf_aligner->align_status.score = score;
+            return 1; // Done
+        }
+        return 0; // Not done
+    }
+    // Multithreading dispatcher
+    const int lo = mwavefront->lo;
+    const int hi = mwavefront->hi;
+    wf_offset_t max_antidiag = 0;
+    const int num_threads = wavefront_compute_num_threads(wf_aligner,lo,hi);
+    if (num_threads == 1) {
+        // Extend wavefront
+        max_antidiag = wavefront_extend_matches_custom_max(wf_aligner,mwavefront,lo,hi);
+    } else {
+#ifdef WFA_PARALLEL
+        // Extend wavefront in parallel
+        #pragma omp parallel num_threads(num_threads)
+        {
+            int t_lo, t_hi;
+            wavefront_compute_thread_limits(
+                    omp_get_thread_num(),omp_get_num_threads(),lo,hi,&t_lo,&t_hi);
+            wf_offset_t t_max_antidiag = wavefront_extend_matches_custom_max(wf_aligner,mwavefront,t_lo,t_hi);
+            #pragma omp critical
+            {
+                if (t_max_antidiag > max_antidiag) max_antidiag = t_max_antidiag;
+            }
+        }
+#endif
+    }
+    // Check end-to-end finished
+    const bool end_reached = wavefront_extend_end2end_check_termination(wf_aligner,mwavefront,score,score_mod);
+    if (end_reached) {
+        wf_aligner->align_status.status = WF_STATUS_END_REACHED;
+        wf_aligner->align_status.score = score;
+        return 1; // Done
+    }
+    // Cut-off wavefront heuristically
+    if (wf_aligner->heuristic.strategy != wf_heuristic_none) {
+        wavefront_heuristic_cufoff(wf_aligner,score,score_mod);
+    }
+    *max_antidiagonal = max_antidiag;
+    return 0; // Not done
+}

--- a/wavefront/wavefront_extend.h
+++ b/wavefront/wavefront_extend.h
@@ -50,5 +50,8 @@ int wavefront_extend_endsfree(
 int wavefront_extend_custom(
     wavefront_aligner_t* const wf_aligner,
     const int score);
-
+int wavefront_extend_custom_max(
+    wavefront_aligner_t* const wf_aligner,
+    const int score,
+    int* const max_antidiagonal);
 #endif /* WAVEFRONT_EXTEND_H_ */

--- a/wavefront/wavefront_unialign.h
+++ b/wavefront/wavefront_unialign.h
@@ -40,8 +40,10 @@
 void wavefront_unialign_resize(
     wavefront_aligner_t* const wf_aligner,
     const char* const pattern,
+    const int* const pattern_lambda,
     const int pattern_length,
     const char* const text,
+    const int* const text_lambda,
     const int text_length,
     const bool reverse_sequences);
 
@@ -55,8 +57,10 @@ void wavefront_unialign_initialize_wavefronts(
 void wavefront_unialign_init(
     wavefront_aligner_t* const wf_aligner,
     const char* const pattern,
+    const int* const pattern_lambda,
     const int pattern_length,
     const char* const text,
+    const int* const text_lambda,
     const int text_length,
     const affine2p_matrix_type component_begin,
     const affine2p_matrix_type component_end);


### PR DESCRIPTION
This 'lambderizes' the standard `BiWFA`.

There were 2 main issues:
- `BiWFA` uses (three) aligners that can work on subsequences, that is on portions of the dynamic programming (DP) matrix, but the previous WFlambda implementation assumed to always work with the entire matrix, with `(h,v)` indices starting from `(0,0)`;
- one of the `BiWFA`'s aligners works on the contrary, that is, with reversed sequences. However, with `WFλ`, there are no actual sequences, so there is nothing to reverse.

The idea is to introduce two 'fake' sequences also for `WFλ`. Instead of having the characters to compare, those sequences are vectors of `int` that contain the coordinates where to explore the 'fake' DP matrix (also called the "high-order DP matrix" in our jargon). These fake sequences mock the underlying `WFA` algorithm by acting as actual ones, but when we call the lambda function (also called the 'match function'), instead of passing directly the coordinates `(v,h)` as parameters, we pass `(fake_pattern[v],fake_text[h])`. In this way, we can work on subregions of the high-order DP matrix (working with pieces of the fake sequences), and also in reverse, as we can reverse the fake sequences, which involves exploring the high-order DP matrix in reverse.

All this comes at the price of adding another 2 parameters to the interfaces of different functions to represent the fake sequences, that is `pattern_lambda` and `text_lambda`.