### PR TITLE
wfa2cpp_static should link against wfa2_static

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,7 +163,7 @@ add_library(wfa2cpp SHARED ${wfa2cpp_SOURCE})
 set_target_properties(wfa2cpp PROPERTIES SOVERSION 0)
 set_target_properties(wfa2cpp_static PROPERTIES OUTPUT_NAME wfa2cpp)
 target_link_libraries(wfa2cpp PUBLIC wfa2)
-target_link_libraries(wfa2cpp_static PUBLIC wfa2)
+target_link_libraries(wfa2cpp_static PUBLIC wfa2_static)
 add_library(wfa2::wfa2cpp ALIAS wfa2cpp)
 add_library(wfa2::wfa2cpp_static ALIAS wfa2cpp_static)
 


### PR DESCRIPTION
Otherwise, when one adds `wfa2cpp_static` as a dependency, only the cpp part is linked statically, but there is still a dependency on a shared `libwfa2.so`.

(I did not notice this when I submitted #48 because CMake ensures binaries find the shared libraries they link against as long as the binary is still in the build folder (by setting a RUNPATH), so there was no error message. )