### PR TITLE
docs: fix doc command

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Git clone and compile the library, tools, and examples. By default use cmake:
 ```
 git clone https://github.com/smarco/WFA2-lib
 cd WFA2-lib
-mkdir build
+mkdir build && cd build
 cmake .. -DCMAKE_BUILD_TYPE=Release
 cmake --build . --verbose
 ctest . --verbose


### PR DESCRIPTION
Small update to the README for building. I think the intent is to be in `build` when `cmake .. -DCMAKE_BUILD_TYPE=Release` is ran?