### PR TITLE
Error: `uint64_t` does not name a type

### DIFF
--- a/utils/commons.h
+++ b/utils/commons.h
@@ -31,6 +31,7 @@
 
 #pragma once
 
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>

--- a/utils/vector.h
+++ b/utils/vector.h
@@ -33,6 +33,8 @@
 #ifndef VECTOR_H_
 #define VECTOR_H_
 
+#include <stdint.h>
+
 /*
  * Checkers
  */


### PR DESCRIPTION
I'm getting the following compile error when running `make` in a fresh clone, probably after updating my system to `gcc 13`:
```
make --directory=alignment all
make[1]: Entering directory '/tmp/philae/WFA2-lib/alignment'
make[1]: Nothing to be done for 'all'.
make[1]: Leaving directory '/tmp/philae/WFA2-lib/alignment'
make --directory=bindings/cpp all
make[1]: Entering directory '/tmp/philae/WFA2-lib/bindings/cpp'
g++ -Wall -g -O3 -march=native  -I../.. -c WFAligner.cpp -o ../../build/cpp/WFAligner.o
In file included from ../../system/mm_allocator.h:38,
                 from ../../wavefront/wfa.h:34,
                 from ../../wavefront/wfa.hpp:35,
                 from WFAligner.hpp:37,
                 from WFAligner.cpp:32:
../../utils/vector.h:46:3: error: ‘uint64_t’ does not name a type
   46 |   uint64_t used;
      |   ^~~~~~~~
../../utils/vector.h:1:1: note: ‘uint64_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
  +++ |+#include <cstdint>
    1 | /*

<many more errors about uint64_t omitted>
```