### PR TITLE
Newer `gcc`s happy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ UNAME=$(shell uname)
 CC:=$(CC)
 CPP:=$(CXX)
 
-CC_FLAGS=-Wall -g
+CC_FLAGS=-Wall -g -fPIE
 
 AR=ar
 AR_FLAGS=-rsc

--- a/bindings/cpp/WFAligner.hpp
+++ b/bindings/cpp/WFAligner.hpp
@@ -33,6 +33,7 @@
 #define BINDINGS_CPP_WFALIGNER_HPP_
 
 #include <string>
+#include <cstdint>
 
 #include "../../wavefront/wfa.hpp"
 


### PR DESCRIPTION
With

```shell
-- The C compiler identification is GNU 11.4.0
-- The CXX compiler identification is GNU 11.4.0
```

I need to add `-fPIE` in `CC_FLAGS`, else I get

```shell
...
[ 63%] Building CXX object src/common/wflign/CMakeFiles/libwflign_static.dir/src/murmur3.cpp.o
[ 72%] Linking CXX static library ../../../lib/libwflign.a
[ 72%] Built target libwflign_static
[ 90%] Building CXX object CMakeFiles/wfmash.dir/src/interface/main.cpp.o
[ 90%] Building CXX object CMakeFiles/wfmash.dir/src/common/utils.cpp.o
[100%] Linking CXX executable bin/wfmash
/usr/bin/ld: /home/guarracino/git/wfmash/src/common/wflign/deps/WFA2-lib/lib/libwfacpp.a(WFAligner.o): relocation R_X86_64_32 against `.rodata.str1.8' can not be used when making a PIE object; recompile with -fPIE
/usr/bin/ld: failed to set dynamic section sizes: bad value
collect2: error: ld returned 1 exit status
gmake[2]: *** [CMakeFiles/wfmash.dir/build.make:114: bin/wfmash] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:102: CMakeFiles/wfmash.dir/all] Error 2
gmake: *** [Makefile:136: all] Error 2
```

This is not needed with `gcc` 13.1.0, but I suppose having such a flag, in any case, would not hurt.

What do you think?