### PR TITLE
Allow zero gap open cost in affine2p

### DIFF
--- a/wavefront/wavefront_penalties.c
+++ b/wavefront/wavefront_penalties.c
@@ -133,11 +133,11 @@ void wavefront_penalties_set_affine2p(
     fprintf(stderr,"[WFA::Penalties] Match score must be negative or zero (M=%d)\n",affine2p_penalties->match);
     exit(1);
   } else if (affine2p_penalties->mismatch <= 0 ||
-             affine2p_penalties->gap_opening1 <= 0 ||
+             affine2p_penalties->gap_opening1 < 0 ||
              affine2p_penalties->gap_extension1 <= 0 ||
-             affine2p_penalties->gap_opening2 <= 0 ||
+             affine2p_penalties->gap_opening2 < 0 ||
              affine2p_penalties->gap_extension2 <= 0) {
-    fprintf(stderr,"[WFA::Penalties] Penalties (X=%d,O1=%d,E1=%d,O2=%d,E2=%d) must be (X>0,O1>=0,E1>0,O1>=0,E1>0)\n",
+    fprintf(stderr,"[WFA::Penalties] Penalties (X=%d,O1=%d,E1=%d,O2=%d,E2=%d) must be (X>0,O1>=0,E1>0,O2>=0,E2>0)\n",
         affine2p_penalties->mismatch,
         affine2p_penalties->gap_opening1,
         affine2p_penalties->gap_extension1,


### PR DESCRIPTION
There is a discrepancy between the error message and check when a gap open cost of zero is used in the dual-gap affine mode. The method appears to work with zero gap opening cost so I changed the check to match the error message here.

It also looks like this issue has come up and been addressed before (https://github.com/smarco/WFA2-lib/issues/52), but I don't see the change on the main branch:
