### PR TITLE
Fix uninitialized memory issues in valgrind

### DIFF
--- a/wavefront/wavefront_sequences.c
+++ b/wavefront/wavefront_sequences.c
@@ -73,7 +73,7 @@ void wavefront_sequences_init_allocate(
     if (wf_sequences->seq_buffer != NULL) free(wf_sequences->seq_buffer);
     // Allocate
     const int proposed_size = buffer_size + buffer_size/2;
-    wf_sequences->seq_buffer = malloc(proposed_size);
+    wf_sequences->seq_buffer = calloc(proposed_size, 1);
     wf_sequences->seq_buffer_allocated = proposed_size;
   }
   // Assign memory


### PR DESCRIPTION
This is one fix for the issue described in https://github.com/smarco/WFA2-lib/issues/76, where I further detail the problem.