### PR TITLE
Add more includes to header files

### DIFF
--- a/alignment/cigar.h
+++ b/alignment/cigar.h
@@ -32,6 +32,7 @@
 #ifndef CIGAR_H_
 #define CIGAR_H_
 
+#include <stdbool.h>
 #include "system/mm_allocator.h"
 #include "alignment/linear_penalties.h"
 #include "alignment/affine_penalties.h"

--- a/system/mm_allocator.h
+++ b/system/mm_allocator.h
@@ -35,6 +35,7 @@
 #ifndef MM_ALLOCATOR_H_
 #define MM_ALLOCATOR_H_
 
+#include <stdbool.h>
 #include "utils/vector.h"
 
 /*

--- a/utils/vector.h
+++ b/utils/vector.h
@@ -34,6 +34,7 @@
 #define VECTOR_H_
 
 #include <stdint.h>
+#include <stdbool.h>
 
 /*
  * Checkers


### PR DESCRIPTION
This fixes some errors (related to the `bool` type not being defined) I was getting while trying to compile Python bindings from the WFA2-lib headers.

Could you consider also porting this to v2.3.3 on a branch and release something like v2.3.4? Since the API on `main` has [changed a bit](https://github.com/smarco/WFA2-lib/issues/82) since v2.3.3.