### PR TITLE
Fix endian.h build error on MacOS

### DIFF
--- a/wavefront/wavefront_extend_kernels.c
+++ b/wavefront/wavefront_extend_kernels.c
@@ -29,7 +29,11 @@
  * DESCRIPTION: WFA module for the "extension" of exact matches
  */
 
-#include <endian.h>
+#ifdef __APPLE__ || defined(__FreeBSD__)
+ #include <machine/endian.h>  // __BYTE_ORDER
+ #else
+ #include <endian.h>  // __BYTE_ORDER
+ #endif
 
 #include "wavefront_extend_kernels.h"
 #include "wavefront_termination.h"


### PR DESCRIPTION
I am currently attempting to update this software's Bioconda recipe to the new release (v2.3.4):  https://github.com/bioconda/bioconda-recipes/pull/43248 and ran into a build error involving `endian.h` on MacOS (Linux builds fine; see the [Azure logs](https://dev.azure.com/bioconda/bioconda-recipes/_build/results?buildId=41956&view=logs&j=1b052f1d-4456-52f0-9d43-71c4c5bd734d&t=edc48dcd-1fc2-5e3b-7036-7be9cea00123&l=497)):
```
/opt/mambaforge/envs/bioconda/conda-bld/wfa2-lib_1695658441139/work/wavefront/wavefront_extend_kernels.c:32:10: fatal error: 'endian.h' file not found
#include <endian.h>
         ^~~~~~~~~~
```

This PR patches the location of `endian.h` header file on line 32 in `wavefront_extend_kernels.c`, which fixes the compilation error on MacOS and FreeBSD.