### PR TITLE
Remove some unused headers

### DIFF
--- a/utils/commons.h
+++ b/utils/commons.h
@@ -47,18 +47,15 @@
 #include <sys/time.h>
 
 #include <sys/stat.h>
-#include <sys/mman.h>
 #include <fcntl.h>
 #include <unistd.h>
 #include <limits.h>
-#include <pwd.h>
 
 #include <string.h>
 #include <math.h>
 #include <stdarg.h>
 #include <getopt.h>
 
-#include <err.h>
 #include <errno.h>
 #include <assert.h>
 #include <signal.h>


### PR DESCRIPTION
I was trying to compile this under windows using mingw, and some headers are not available there.
However, it seems like those headers are not used anywhere in the library anyway (at least it compiles fine on windows after i remove these).
At least for `pwd.h` and `err.h` I'm fairly certain that they're not used anywhere since it would be weird to use them in this library, for `sys/mman.h` it would certainly be plausible they'd be used here, but I could not find any `mmap`/`madvice`/`mlock` calls. 