### PR TITLE
Don't use parallel alignment if it is not available

### DIFF
--- a/tools/align_benchmark/Makefile
+++ b/tools/align_benchmark/Makefile
@@ -8,7 +8,11 @@ FOLDER_BIN=$(FOLDER_ROOT)/bin
 FOLDER_BUILD=./build
 
 ifeq ($(UNAME), Linux)
-  LD_FLAGS+=-lrt 
+  LD_FLAGS+=-lrt
+endif
+
+ifeq ($(BUILD_WFA_PARALLEL),1)
+PFLAGS=-DWFA_PARALLEL -fopenmp
 endif
 
 LI_FLAGS=-L$(FOLDER_LIB) -I$(FOLDER_ROOT) -I$(FOLDER_WFA) -I.
@@ -23,27 +27,27 @@ SUBDIRS=benchmark \
         gap_linear \
         indel
 BIN=$(FOLDER_BIN)/align_benchmark
-        
-all: setup 
+
+all: setup
 all: $(SUBDIRS)
 all: OBJS+=$(FOLDER_BUILD)/*.o
 all: align_benchmark
 
 align_benchmark: */*.c */*.h align_benchmark.c $(LIB_WFA)
-	$(CC) $(CC_FLAGS) $(LI_FLAGS) $(OBJS) align_benchmark_params.c align_benchmark.c -o $(BIN) $(LD_FLAGS) -lwfa -lm -fopenmp
-	
+	$(CC) $(CC_FLAGS) $(LI_FLAGS) $(PFLAGS) $(OBJS) align_benchmark_params.c align_benchmark.c -o $(BIN) $(LD_FLAGS) -lwfa -lm -fopenmp
+
 setup:
 	@mkdir -p $(FOLDER_BUILD)
 
-clean: 
+clean:
 	rm -rf $(FOLDER_BUILD)
-	
+
 ###############################################################################
 # Subdir rule
 ###############################################################################
 export
 $(SUBDIRS):
 	$(MAKE) --directory=$@ all
-	
+
 .PHONY: $(SUBDIRS)
 

--- a/tools/align_benchmark/align_benchmark.c
+++ b/tools/align_benchmark/align_benchmark.c
@@ -502,6 +502,10 @@ void align_benchmark_sequential() {
   free(parameters.line2);
 }
 void align_benchmark_parallel() {
+  #ifndef WFA_PARALLEL
+    fprintf(stderr,"Parallel execution not supported. Compile with BUILD_WFA_PARALLEL=1\n");
+    exit(1);
+  #endif
   // PROFILE
   timer_reset(&parameters.timer_global);
   // Open input file

--- a/tools/align_benchmark/align_benchmark_params.c
+++ b/tools/align_benchmark/align_benchmark_params.c
@@ -170,7 +170,12 @@ void usage() {
       "          --check-bandwidth INT                                         \n"
       "          --plot                                                        \n"
       "        [System]                                                        \n"
+      #ifndef WFA_PARALLEL
+      "          --num-threads|t INT [n/a]  Compile with BUILD_WFA_PARALLEL=1  \n"
+      "                                     to be able to use this feature.    \n"
+      #else
       "          --num-threads|t INT                                           \n"
+      #endif
       "          --batch-size INT                                              \n"
     //"          --progress|P INT                                              \n"
       "          --verbose|v INT                                               \n"


### PR DESCRIPTION
If WFA2-lib was compiled without parallel support (the current default), the `align_benchmark` tool could still be used with the `-t` option, but the reported times were all 0s.