### PR TITLE
Fix static band heuristic for high, medium, and low memory modes

### DIFF
--- a/wavefront/wavefront_backtrace.c
+++ b/wavefront/wavefront_backtrace.c
@@ -68,8 +68,8 @@ int64_t wavefront_backtrace_misms(
   if (score < 0) return WAVEFRONT_OFFSET_NULL;
   wavefront_t* const mwavefront = wf_aligner->wf_components.mwavefronts[score];
   if (mwavefront != NULL &&
-      mwavefront->lo <= k &&
-      k <= mwavefront->hi) {
+      mwavefront->wf_elements_init_min <= k &&
+      k <= mwavefront->wf_elements_init_max) {
     return BACKTRACE_PIGGYBACK_SET(mwavefront->offsets[k]+1,backtrace_M);
   } else {
     return WAVEFRONT_OFFSET_NULL;
@@ -109,8 +109,8 @@ int64_t wavefront_backtrace_del1_open(
   if (score < 0) return WAVEFRONT_OFFSET_NULL;
   wavefront_t* const mwavefront = wf_aligner->wf_components.mwavefronts[score];
   if (mwavefront != NULL &&
-      mwavefront->lo <= k+1 &&
-      k+1 <= mwavefront->hi) {
+      mwavefront->wf_elements_init_min <= k+1 &&
+      k+1 <= mwavefront->wf_elements_init_max) {
     return BACKTRACE_PIGGYBACK_SET(mwavefront->offsets[k+1],backtrace_D1_open);
   } else {
     return WAVEFRONT_OFFSET_NULL;
@@ -123,8 +123,8 @@ int64_t wavefront_backtrace_del2_open(
   if (score < 0) return WAVEFRONT_OFFSET_NULL;
   wavefront_t* const mwavefront = wf_aligner->wf_components.mwavefronts[score];
   if (mwavefront != NULL &&
-      mwavefront->lo <= k+1 &&
-      k+1 <= mwavefront->hi) {
+      mwavefront->wf_elements_init_min <= k+1 &&
+      k+1 <= mwavefront->wf_elements_init_max) {
     return BACKTRACE_PIGGYBACK_SET(mwavefront->offsets[k+1],backtrace_D2_open);
   } else {
     return WAVEFRONT_OFFSET_NULL;
@@ -137,8 +137,8 @@ int64_t wavefront_backtrace_del1_ext(
   if (score < 0) return WAVEFRONT_OFFSET_NULL;
   wavefront_t* const d1wavefront = wf_aligner->wf_components.d1wavefronts[score];
   if (d1wavefront != NULL &&
-      d1wavefront->lo <= k+1 &&
-      k+1 <= d1wavefront->hi) {
+      d1wavefront->wf_elements_init_min <= k+1 &&
+      k+1 <= d1wavefront->wf_elements_init_max) {
     return BACKTRACE_PIGGYBACK_SET(d1wavefront->offsets[k+1],backtrace_D1_ext);
   } else {
     return WAVEFRONT_OFFSET_NULL;
@@ -151,8 +151,8 @@ int64_t wavefront_backtrace_del2_ext(
   if (score < 0) return WAVEFRONT_OFFSET_NULL;
   wavefront_t* const d2wavefront = wf_aligner->wf_components.d2wavefronts[score];
   if (d2wavefront != NULL &&
-      d2wavefront->lo <= k+1 &&
-      k+1 <= d2wavefront->hi) {
+      d2wavefront->wf_elements_init_min <= k+1 &&
+      k+1 <= d2wavefront->wf_elements_init_max) {
     return BACKTRACE_PIGGYBACK_SET(d2wavefront->offsets[k+1],backtrace_D2_ext);
   } else {
     return WAVEFRONT_OFFSET_NULL;
@@ -168,8 +168,8 @@ int64_t wavefront_backtrace_ins1_open(
   if (score < 0) return WAVEFRONT_OFFSET_NULL;
   wavefront_t* const mwavefront = wf_aligner->wf_components.mwavefronts[score];
   if (mwavefront != NULL &&
-      mwavefront->lo <= k-1 &&
-      k-1 <= mwavefront->hi) {
+      mwavefront->wf_elements_init_min <= k-1 &&
+      k-1 <= mwavefront->wf_elements_init_max) {
     return BACKTRACE_PIGGYBACK_SET(mwavefront->offsets[k-1]+1,backtrace_I1_open);
   } else {
     return WAVEFRONT_OFFSET_NULL;
@@ -182,8 +182,8 @@ int64_t wavefront_backtrace_ins2_open(
   if (score < 0) return WAVEFRONT_OFFSET_NULL;
   wavefront_t* const mwavefront = wf_aligner->wf_components.mwavefronts[score];
   if (mwavefront != NULL &&
-      mwavefront->lo <= k-1 &&
-      k-1 <= mwavefront->hi) {
+      mwavefront->wf_elements_init_min <= k-1 &&
+      k-1 <= mwavefront->wf_elements_init_max) {
     return BACKTRACE_PIGGYBACK_SET(mwavefront->offsets[k-1]+1,backtrace_I2_open);
   } else {
     return WAVEFRONT_OFFSET_NULL;
@@ -196,8 +196,8 @@ int64_t wavefront_backtrace_ins1_ext(
   if (score < 0) return WAVEFRONT_OFFSET_NULL;
   wavefront_t* const i1wavefront = wf_aligner->wf_components.i1wavefronts[score];
   if (i1wavefront != NULL &&
-      i1wavefront->lo <= k-1 &&
-      k-1 <= i1wavefront->hi) {
+      i1wavefront->wf_elements_init_min <= k-1 &&
+      k-1 <= i1wavefront->wf_elements_init_max) {
     return BACKTRACE_PIGGYBACK_SET(i1wavefront->offsets[k-1]+1,backtrace_I1_ext);
   } else {
     return WAVEFRONT_OFFSET_NULL;
@@ -210,8 +210,8 @@ int64_t wavefront_backtrace_ins2_ext(
   if (score < 0) return WAVEFRONT_OFFSET_NULL;
   wavefront_t* const i2wavefront = wf_aligner->wf_components.i2wavefronts[score];
   if (i2wavefront != NULL &&
-      i2wavefront->lo <= k-1 &&
-      k-1 <= i2wavefront->hi) {
+      i2wavefront->wf_elements_init_min <= k-1 &&
+      k-1 <= i2wavefront->wf_elements_init_max) {
     return BACKTRACE_PIGGYBACK_SET(i2wavefront->offsets[k-1]+1,backtrace_I2_ext);
   } else {
     return WAVEFRONT_OFFSET_NULL;

--- a/wavefront/wavefront_heuristic.c
+++ b/wavefront/wavefront_heuristic.c
@@ -165,9 +165,6 @@ void wf_heuristic_equate(
     if (wavefront_src->lo > wavefront_dst->lo) wavefront_dst->lo = wavefront_src->lo;
     if (wavefront_src->hi < wavefront_dst->hi) wavefront_dst->hi = wavefront_src->hi;
     if (wavefront_dst->lo > wavefront_dst->hi) wavefront_dst->null = true;
-    // Save min/max WF initialized
-    wavefront_dst->wf_elements_init_min = wavefront_dst->lo;
-    wavefront_dst->wf_elements_init_max = wavefront_dst->hi;
   }
 }
 /*
@@ -548,9 +545,6 @@ bool wavefront_heuristic_cufoff(
   // const int wf_length_reduced = mwavefront->hi-mwavefront->lo+1;
   // fprintf(stderr,"[WFA::Heuristic] Heuristic from %d to %d offsets (%2.2f%%)\n",
   //    wf_length_base,wf_length_reduced,100.0f*(float)wf_length_reduced/(float)wf_length_base);
-  // Save min/max WF initialized
-  mwavefront->wf_elements_init_min = mwavefront->lo;
-  mwavefront->wf_elements_init_max = mwavefront->hi;
   // Equate other wavefronts
   if (distance_metric <= gap_linear) return false; // Not Dropped
   // Cut-off the other wavefronts (same dimensions as M)


### PR DESCRIPTION
With these changes, I now obtain identical alignments with and without the static band heuristic, provided that the band is wide enough to include the optimal path. Problems are reported in https://github.com/smarco/WFA2-lib/issues/110. The first commit fixes some of the cases, while the second commit fixes the remaining ones. The changes affect memory modes high, medium, and low. Ultralow + heuristic remains broken ;(
