### PR TITLE
Fix #125: inherit static band into BiWFA sub-aligners and clamp compu…

### DIFF
--- a/wavefront/wavefront_bialign.c
+++ b/wavefront/wavefront_bialign.c
@@ -78,10 +78,34 @@ void wavefront_bialign_debug(
   fprintf(stderr,")\n");
 }
 /*
+ * Static Band Heuristic Set Bands 
+ */
+void wavefront_bialign_set_subsidiary_band(
+    wavefront_aligner_t* const wf_aligner,
+    wavefront_aligner_t* const wf_forward,
+    wavefront_aligner_t* const wf_reverse) {
+  const wf_heuristic_strategy strategy = wf_aligner->heuristic.strategy;
+  if ((strategy & wf_heuristic_banded_static) == 0 &&
+      (strategy & wf_heuristic_banded_adaptive) == 0) {
+    return;
+  }
+  const int global_min_k = wf_aligner->heuristic.min_k;
+  const int global_max_k = wf_aligner->heuristic.max_k;
+  //Update bands for forward alignemnt
+  const wavefront_sequences_t* const sequences = &wf_forward->sequences;
+  const int sub_diagonal_shift = sequences->text_begin - sequences->pattern_begin;
+  wf_forward->heuristic.min_k = global_min_k - sub_diagonal_shift;
+  wf_forward->heuristic.max_k = global_max_k - sub_diagonal_shift;
+  //Update bands for reverse alignemnt 
+  const int diagonal_shift = sequences->text_length - sequences->pattern_length;
+  wf_reverse->heuristic.min_k = diagonal_shift - wf_forward->heuristic.max_k;
+  wf_reverse->heuristic.max_k = diagonal_shift - wf_forward->heuristic.min_k;
+}
+/*
  * Init
  */
 void wavefront_bialign_init(
-    wavefront_bialigner_t* const bialigner,
+    wavefront_aligner_t* const wf_aligner,
     const distance_metric_t distance_metric,
     alignment_form_t* const form,
     const affine2p_matrix_type component_begin,
@@ -89,8 +113,10 @@ void wavefront_bialign_init(
     const int align_level,
     const int verbose) {
   // Parameters
+  wavefront_bialigner_t* const bialigner = wf_aligner->bialigner;
   wavefront_aligner_t* const wf_forward = bialigner->wf_forward;
   wavefront_aligner_t* const wf_reverse = bialigner->wf_reverse;
+  wavefront_bialign_set_subsidiary_band(wf_aligner,wf_forward,wf_reverse);
   // Configure WF-compute function
   switch (distance_metric) {
     case indel:
@@ -167,6 +193,17 @@ int wavefront_bialign_base(
   const int verbose = wf_base->system.verbose;
   // Configure
   wf_base->alignment_form = *form;
+  wf_base->heuristic = wf_aligner->heuristic;
+  // Inherit heuristic band from master aligner
+  if ((wf_aligner->heuristic.strategy & wf_heuristic_banded_static)   != 0 ||
+      (wf_aligner->heuristic.strategy & wf_heuristic_banded_adaptive) != 0) {
+    const int global_min_k = wf_aligner->heuristic.min_k;
+    const int global_max_k = wf_aligner->heuristic.max_k;
+    const wavefront_sequences_t* const sequences = &wf_base->sequences;
+    const int diagonal_shift = sequences->text_begin - sequences->pattern_begin;
+    wf_base->heuristic.min_k = global_min_k - diagonal_shift;
+    wf_base->heuristic.max_k = global_max_k - diagonal_shift;
+  }
   wavefront_unialign_init(wf_base,component_begin,component_end);
   // DEBUG
   if (verbose >= 2) wavefront_debug_begin(wf_base);
@@ -972,7 +1009,7 @@ int wavefront_bialign_overlap_gopen_adjust(
   }
 }
 int wavefront_bialign_find_breakpoint(
-    wavefront_bialigner_t* const bialigner,
+    wavefront_aligner_t* const wf_aligner,
     const distance_metric_t distance_metric,
     alignment_form_t* const form,
     const affine2p_matrix_type component_begin,
@@ -980,13 +1017,14 @@ int wavefront_bialign_find_breakpoint(
     wf_bialign_breakpoint_t* const breakpoint,
     const int align_level) {
   // Parameters
+  wavefront_bialigner_t* const bialigner = wf_aligner->bialigner;
   wavefront_aligner_t* const wf_forward = bialigner->wf_forward;
   wavefront_aligner_t* const wf_reverse = bialigner->wf_reverse;
   alignment_system_t* const system = &wf_forward->system;
   const bool plot_enabled = (wf_forward->plot != NULL);
   const int verbose = system->verbose;
   // Init bialignment
-  wavefront_bialign_init(bialigner,distance_metric,form,component_begin,component_end,align_level,verbose);
+  wavefront_bialign_init(wf_aligner,distance_metric,form,component_begin,component_end,align_level,verbose);
   // Sequences
   wavefront_sequences_t* const sequences = &wf_forward->sequences;
   const int text_length = sequences->text_length;
@@ -1171,7 +1209,7 @@ int wavefront_bialign_alignment(
   // Find breakpoint in the alignment
   wf_bialign_breakpoint_t breakpoint;
   int align_status = wavefront_bialign_find_breakpoint(
-      wf_aligner->bialigner,wf_aligner->penalties.distance_metric,
+      wf_aligner,wf_aligner->penalties.distance_metric,
       form,component_begin,component_end,&breakpoint,align_level);
   // DEBUG
   if (wf_aligner->system.verbose >= 2) {
@@ -1234,7 +1272,7 @@ int wavefront_bialign_compute_score(
   cigar_clear(wf_aligner->cigar);
   // Find breakpoint in the alignment
   wf_bialign_breakpoint_t breakpoint;
-  const int align_status = wavefront_bialign_find_breakpoint(wf_aligner->bialigner,
+  const int align_status = wavefront_bialign_find_breakpoint(wf_aligner,
       wf_aligner->penalties.distance_metric,&wf_aligner->alignment_form,
       affine_matrix_M,affine_matrix_M,&breakpoint,0);
   // DEBUG

--- a/wavefront/wavefront_compute.c
+++ b/wavefront/wavefront_compute.c
@@ -35,6 +35,22 @@
 #include "wavefront_compute.h"
 
 /*
+ * Compute global alignment limits for heuristic
+*/
+void wavefront_compute_limits_heuristic(
+  wavefront_aligner_t* const wf_aligner,
+  int* const lo,
+  int* const hi
+) {
+  const wf_heuristic_strategy strategy = wf_aligner->heuristic.strategy;
+  const bool banded_enabled = (strategy & (wf_heuristic_banded_static | wf_heuristic_banded_adaptive));
+  // Clamp to static band limits
+  if (banded_enabled) {
+    if (*lo < (wf_aligner->heuristic.min_k)) *lo = wf_aligner->heuristic.min_k;
+    if (*hi > (wf_aligner->heuristic.max_k)) *hi = wf_aligner->heuristic.max_k;
+  }
+}
+/*
  * Compute limits
  */
 void wavefront_compute_limits_input(
@@ -53,6 +69,7 @@ void wavefront_compute_limits_input(
   if (min_lo > m_open1->lo-1) min_lo = m_open1->lo-1;
   if (max_hi < m_open1->hi+1) max_hi = m_open1->hi+1;
   if (distance_metric == gap_linear) {
+    wavefront_compute_limits_heuristic(wf_aligner,&min_lo,&max_hi);
     *lo = min_lo;
     *hi = max_hi;
     return;
@@ -66,6 +83,7 @@ void wavefront_compute_limits_input(
   if (min_lo > d1_ext->lo-1) min_lo = d1_ext->lo-1;
   if (max_hi < d1_ext->hi-1) max_hi = d1_ext->hi-1;
   if (distance_metric == gap_affine) {
+    wavefront_compute_limits_heuristic(wf_aligner,&min_lo,&max_hi);
     *lo = min_lo;
     *hi = max_hi;
     return;
@@ -81,6 +99,7 @@ void wavefront_compute_limits_input(
   if (max_hi < i2_ext->hi+1) max_hi = i2_ext->hi+1;
   if (min_lo > d2_ext->lo-1) min_lo = d2_ext->lo-1;
   if (max_hi < d2_ext->hi-1) max_hi = d2_ext->hi-1;
+  wavefront_compute_limits_heuristic(wf_aligner,&min_lo,&max_hi);
   *lo = min_lo;
   *hi = max_hi;
 }


### PR DESCRIPTION
…te limits

Propagate the banded-static heuristic into the bialigner forward/reverse/base aligners with correct diagonal shifts, and clamp wavefront compute limits to the static band. Makes banded BiWFA (ultralow) return the optimal alignment instead of clipping it, eliminating silently-degraded reconstructions.